### PR TITLE
Added unique listener ID, and updated package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10"
+  - "iojs"
+sudo: false
+cache:
+  directories:
+    - node_modules
 notifications:
   email: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,6 @@
 'use strict';
 
-module.exports = function(grunt) {
-
-  grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.loadNpmTasks('grunt-release');
+module.exports = function (grunt) {
 
   grunt.initConfig({
     mochaTest: {
@@ -22,17 +19,13 @@ module.exports = function(grunt) {
       }
     },
     watch: {
-      files: ['Gruntfile.js', 'test/**/*.coffee'],
+      files: ['Gruntfile.js', 'src/**/*.coffee', 'test/**/*.coffee'],
       tasks: ['test']
     }
   });
 
-  grunt.event.on('watch', function(action, filepath, target) {
-    grunt.log.writeln(target + ': ' + filepath + ' has ' + action);
-  });
-
   // load all grunt tasks
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  require('matchdep').filterDev(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
 
   grunt.registerTask('test', ['mochaTest']);
   grunt.registerTask('test:watch', ['watch']);

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Then add **hubot-diagnostics** to your `external-scripts.json`:
 ## Sample Interaction
 
 ```
-user1>> hubot hello
-hubot>> hello!
+user1>> hubot ping
+hubot>> PONG
 ```

--- a/index.coffee
+++ b/index.coffee
@@ -3,10 +3,9 @@ path = require 'path'
 
 module.exports = (robot, scripts) ->
   scriptsPath = path.resolve(__dirname, 'src')
-  fs.exists scriptsPath, (exists) ->
-    if exists
-      for script in fs.readdirSync(scriptsPath)
-        if scripts? and '*' not in scripts
-          robot.loadFile(scriptsPath, script) if script in scripts
-        else
-          robot.loadFile(scriptsPath, script)
+  if fs.existsSync scriptsPath
+    for script in fs.readdirSync(scriptsPath).sort()
+      if scripts? and '*' not in scripts
+        robot.loadFile(scriptsPath, script) if script in scripts
+      else
+        robot.loadFile(scriptsPath, script)

--- a/package.json
+++ b/package.json
@@ -17,15 +17,18 @@
     "hubot": "2.x"
   },
   "devDependencies": {
+    "chai": "^2.1.1",
+    "coffee-script": "1.6.3",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.12.7",
+    "grunt-release": "~0.11.0",
     "hubot": "2.x",
-    "mocha": "*",
-    "chai": "*",
-    "sinon-chai": "*",
-    "sinon": "*",
-    "grunt-mocha-test": "~0.7.0",
-    "grunt-release": "~0.6.0",
-    "matchdep": "~0.1.2",
-    "grunt-contrib-watch": "~0.5.3"
+    "matchdep": "~0.3.0",
+    "mocha": "^2.1.0",
+    "sinon": "^1.13.0",
+    "sinon-chai": "^2.7.0"
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/diagnostics.coffee
+++ b/src/diagnostics.coffee
@@ -11,14 +11,14 @@
 #   Josh Nichols <technicalpickles@github.com>
 
 module.exports = (robot) ->
-  robot.respond /PING$/i, (msg) ->
+  robot.respond /PING$/i, id: "diagnostics.ping", (msg) ->
     msg.send "PONG"
 
-  robot.respond /ADAPTER$/i, (msg) ->
+  robot.respond /ADAPTER$/i, id: "diagnostics.adapter", (msg) ->
     msg.send robot.adapterName
 
-  robot.respond /ECHO (.*)$/i, (msg) ->
+  robot.respond /ECHO (.*)$/i, id: "diagnostics.echo", (msg) ->
     msg.send msg.match[1]
 
-  robot.respond /TIME$/i, (msg) ->
+  robot.respond /TIME$/i, id: "diagnostics.time", (msg) ->
     msg.send "Server time is: #{new Date()}"

--- a/test/diagnostics-test.coffee
+++ b/test/diagnostics-test.coffee
@@ -13,7 +13,7 @@ describe 'diagnostics', ->
     require('../src/diagnostics')(@robot)
 
   it 'registers a respond listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/hello/)
-
-  it 'registers a hear listener', ->
-    expect(@robot.hear).to.have.been.calledWith(/orly/)
+    expect(@robot.respond).to.have.been.calledWith(/PING$/i)
+    expect(@robot.respond).to.have.been.calledWith(/ADAPTER$/i)
+    expect(@robot.respond).to.have.been.calledWith(/ECHO (.*)$/i)
+    expect(@robot.respond).to.have.been.calledWith(/TIME$/i)


### PR DESCRIPTION
In light of the recent _major_ [updates](https://github.com/github/hubot/blob/master/CHANGELOG.md#v2160) to Hubot, notably the introduction of listener metadata, I've made several updates to this package to take advantage of them.
- I've added a unique listener ID to all the commands (the ID corresponds to the package name, and the command as per [recommendation](https://hubot.github.com/docs/scripting/#listener-metadata) by the docs)
- Unrelated to the above (and the core of this PR), I've fixed the basic tests to examine the listeners
- I've also updated the package to reflect changes to the `generator-hubot` script [template](https://github.com/github/generator-hubot/tree/master/generators/script/templates) (including changes to dev dependencies)
- Finally, I've updated the `README.md`, because everyone wants to know what `PING` does :smile:

It runs smoothly on my side.

It'll be great if we can at least introduce the metadata for the listeners in this package as I would like commands for diagnostics to be only accessible by a select group of individuals.
