### PR TITLE
Add multiline support to echo command

### DIFF
--- a/src/diagnostics.js
+++ b/src/diagnostics.js
@@ -21,7 +21,7 @@ module.exports = function (robot) {
     msg.send(robot.adapterName)
   })
 
-  robot.respond(/ECHO (.*)$/i, msg => {
+  robot.respond(/ECHO ([\s\S]*)$/im, msg => {
     msg.send(msg.match[1])
   })
 

--- a/test/diagnostics-test.js
+++ b/test/diagnostics-test.js
@@ -72,6 +72,17 @@ describe('diagnostics', () => describe('respond to diagnostic commands', () => {
     return this.robot.adapter.receive(new TextMessage(this.user, 'hubot echo horses are weird'))
   }))
 
+  context('when asked to echo a multiline string', () => it('echoes the multiline string', function (done) {
+    this.robot.adapter.on('send', function (envelope, strings) {
+      expect(strings.length).to.eql(1)
+      expect(strings[0]).to.eql('horses are weird\nviolets are blue')
+
+      return done()
+    })
+
+    return this.robot.adapter.receive(new TextMessage(this.user, 'hubot echo horses are weird\nviolets are blue'))
+  }))
+
   context('when asked for the server time', () => it('responds with the time', function (done) {
     this.robot.adapter.on('send', function (envelope, strings) {
       expect(strings.length).to.eql(1)


### PR DESCRIPTION
We found that the echo command was not working with multiline strings (with the flowdock adapter), so this change adds support for it.

Updated tests as well.